### PR TITLE
fix: RSS-TD-05 change landing page code editor on tablet size disappear

### DIFF
--- a/.vscode/components.code-snippets
+++ b/.vscode/components.code-snippets
@@ -5,7 +5,7 @@
     "description": "Generate base Component View template",
     "body": [
       "import type { IComponentChild } from '@common/types/types';",
-      "import { mergeClassNames } from '@common/utils/class-names';",
+      "import { mergeClassNames } from '@common/utils/class-names.util';",
       "import { Component } from '@components/base/component';",
       "",
       "import styles from './${TM_FILENAME_BASE/(.*)\\.view$/$1/}.module.scss';",

--- a/src/pages/landing-page/components/ui/landing-code-editor/landing-code-editor.module.scss
+++ b/src/pages/landing-page/components/ui/landing-code-editor/landing-code-editor.module.scss
@@ -15,6 +15,10 @@
   }
 
   @include media-desktop-small {
+    max-width: 100%;
+  }
+
+  @include media-tablet {
     display: none;
   }
 

--- a/src/pages/landing-page/landing-page.module.scss
+++ b/src/pages/landing-page/landing-page.module.scss
@@ -19,7 +19,9 @@
 
   @include media-desktop-small {
     padding-bottom: 20px;
-    align-items: center;
+    align-items: start;
+    width: 100%;
+    flex-direction: column-reverse;
   }
 }
 


### PR DESCRIPTION
# 📋 Trello Task ID

- [x] **RSS-TD-05** (Task ID)
- [ ] **No ID** (Global fix or chore)

# ⚡️ Summary

This PR implements fix for media query that includes code editor disappear on tablet and mobile size

# 🛠 Type of change

- [ ] `feat` (New feature)
- [x] `fix` (Bug fix)
- [ ] `refactor` (Code improvement / Refactoring without changing logic)
- [ ] `style` (Formatting, CSS)
- [ ] `docs` (Documentation)
- [ ] `chore` (Configs, Build)

# 🧪 How Has This Been Tested?

- [x] **Manual Testing** (Interface interaction)

**Browsers / Devices:**

- [x] Chrome
- [x] Mobile (Responsive)

# 📷 Screenshots / GIFs

<img width="1314" height="1220" alt="image" src="https://github.com/user-attachments/assets/44de997b-0751-4e46-8b3f-e9d917841ca8" />

# ✅ Checklist:

- [x] My code follows the **Code Standards** of this project
- [x] I have performed a **self-review** of my own code
- [x] I have used **semantic naming** for variables/functions (camelCase)
- [x] My changes generate **no new warnings** in the console
- [x] I have removed `console.log` (except for critical error logging)
